### PR TITLE
Add mise activate to zsh config

### DIFF
--- a/common/zsh/zshrc.symlink
+++ b/common/zsh/zshrc.symlink
@@ -69,3 +69,6 @@ export PATH="$HOME/.local/bin:$PATH"
 # direnv — auto-load .envrc per directory
 eval "$(direnv hook zsh)"
 export PATH=$PATH:$HOME/.maestro/bin
+
+# NIA-863 - mise dev-tool version manager (added by scripts/welcome.mjs)
+eval "$(mise activate zsh)"


### PR DESCRIPTION
## Summary
- Adds `eval "$(mise activate zsh)"` to `common/zsh/zshrc.symlink` so mise-managed tool versions resolve in every interactive shell
- Follow-up on #38 which removed the asdf equivalent — this persists the mise hook the NIA-863 welcome script auto-installs

## Test plan
- [ ] Pull on a fresh machine, open a new terminal, run `mise current` and confirm versions resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)